### PR TITLE
#164132189 An admin user should be able to delete a meetup

### DIFF
--- a/UI/js/create-meetup.js
+++ b/UI/js/create-meetup.js
@@ -43,7 +43,7 @@ const createMeetup = (e) => {
         if (data.status == 201) {
             toggleModal(data.message);
         } else {
-            toggleModal(data.message.error);
+            return data.hasOwnProperty("msg") ? toggleModal(data.msg): data.hasOwnProperty(data.message) ? toggleModal("Your session has expired. Try to log in again."): toggleModal(data.message.error);
         }
     })
     .catch(err => {

--- a/UI/js/display-dashboard.js
+++ b/UI/js/display-dashboard.js
@@ -1,4 +1,4 @@
-const dashboardDisplay = document.getElementById('dashboard-display');
+const dashboardDisplay = document.getElementById("dashboard-display");
 
 const modal        = document.querySelector(".modal");
 const closeDisplay = document.querySelector(".close-display");
@@ -27,7 +27,7 @@ fetch('https://q-questioner-api.herokuapp.com/api/v2/meetups/upcoming/', {
         let meetupData = '';
         meetups.forEach(meetup => {
             meetupData += `
-                <div id=${meetup.id} class="meetup-info">
+                <div id="meetup-${meetup.id}" class="meetup-info">
                     <div class="meetup-title">
                         <p>${meetup.topic.toUpperCase()}</p>
                     </div>
@@ -38,13 +38,18 @@ fetch('https://q-questioner-api.herokuapp.com/api/v2/meetups/upcoming/', {
                         <p>${moment(meetup.happeningOn).format('dddd do MMMM YYYY, h:mm A')}</p>
                     </div>
                     <div class="meetup-id-display">${meetup.id}</div>
-                    <button class="meetup-delete-btn" onclick="getElementById(${meetup.id}).style.display='none'">DELETE</button>
+                    <button id="meetup-delete-${meetup.id}" class="meetup-delete-btn" onclick="getElementById('meetup-${meetup.id}').style.display='none'">DELETE</button>
                 </div>
             `;
         });
         dashboardDisplay.innerHTML += meetupData;
+        meetups.forEach(meetup => {
+            document.getElementById(`meetup-delete-${meetup.id}`).addEventListener('click', () => {
+                console.log(`Meetup with id ${meetup.id} has been deleted.`);
+            });
+        });
     } else {
-        return data ? toggleModal(data.msg): toggleModal(data.message.error);
+        return data.hasOwnProperty("msg") ? toggleModal(data.msg): toggleModal(data.message + ". Session has expired. You have to log in to view the page");
     }
 })
 .catch(err => toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance."));

--- a/UI/js/display-dashboard.js
+++ b/UI/js/display-dashboard.js
@@ -15,7 +15,7 @@ const windowOnClick = (event) => {
     }
 };
 
-fetch('http://127.0.0.1:5000/api/v2/meetups/upcoming/', {
+fetch('https://q-questioner-api.herokuapp.com/api/v2/meetups/upcoming/', {
     headers: {
         'Authorization': `Bearer ${localStorage.getItem('accessToken')}`
     }
@@ -56,7 +56,7 @@ fetch('http://127.0.0.1:5000/api/v2/meetups/upcoming/', {
 .catch(err => toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance."));
 
 const deleteMeetup = (meetupId) => {
-    fetch(`http://127.0.0.1:5000/api/v2/meetups/${meetupId}`, {
+    fetch(`https://q-questioner-api.herokuapp.com/api/v2/meetups/${meetupId}`, {
         method : 'DELETE',
         headers: {
             'Authorization': `Bearer ${localStorage.getItem('accessToken')}`

--- a/UI/js/display-dashboard.js
+++ b/UI/js/display-dashboard.js
@@ -15,7 +15,7 @@ const windowOnClick = (event) => {
     }
 };
 
-fetch('https://q-questioner-api.herokuapp.com/api/v2/meetups/upcoming/', {
+fetch('http://127.0.0.1:5000/api/v2/meetups/upcoming/', {
     headers: {
         'Authorization': `Bearer ${localStorage.getItem('accessToken')}`
     }
@@ -38,13 +38,14 @@ fetch('https://q-questioner-api.herokuapp.com/api/v2/meetups/upcoming/', {
                         <p>${moment(meetup.happeningOn).format('dddd do MMMM YYYY, h:mm A')}</p>
                     </div>
                     <div class="meetup-id-display">${meetup.id}</div>
-                    <button id="meetup-delete-${meetup.id}" class="meetup-delete-btn" onclick="getElementById('meetup-${meetup.id}').style.display='none'">DELETE</button>
+                    <button id="meetup-delete-${meetup.id}" class="meetup-delete-btn">DELETE</button>
                 </div>
             `;
         });
         dashboardDisplay.innerHTML += meetupData;
         meetups.forEach(meetup => {
             document.getElementById(`meetup-delete-${meetup.id}`).addEventListener('click', () => {
+                document.getElementById(`meetup-${meetup.id}`).style.display = "none";
                 console.log(`Meetup with id ${meetup.id} has been deleted.`);
             });
         });

--- a/UI/js/display-dashboard.js
+++ b/UI/js/display-dashboard.js
@@ -45,15 +45,33 @@ fetch('http://127.0.0.1:5000/api/v2/meetups/upcoming/', {
         dashboardDisplay.innerHTML += meetupData;
         meetups.forEach(meetup => {
             document.getElementById(`meetup-delete-${meetup.id}`).addEventListener('click', () => {
+                deleteMeetup(meetup.id);
                 document.getElementById(`meetup-${meetup.id}`).style.display = "none";
-                console.log(`Meetup with id ${meetup.id} has been deleted.`);
             });
         });
     } else {
-        return data.hasOwnProperty("msg") ? toggleModal(data.msg): toggleModal(data.message + ". Session has expired. You have to log in to view the page");
+        return data.hasOwnProperty("msg") ? toggleModal(data.msg): data.hasOwnProperty(data.message) ? toggleModal(data.message): toggleModal(data.message.error);
     }
 })
 .catch(err => toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance."));
+
+const deleteMeetup = (meetupId) => {
+    fetch(`http://127.0.0.1:5000/api/v2/meetups/${meetupId}`, {
+        method : 'DELETE',
+        headers: {
+            'Authorization': `Bearer ${localStorage.getItem('accessToken')}`
+        }
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.status == 200) {
+            toggleModal("Meetup has been succesfully deleted.");
+        } else {
+            toggleModal(data.message.error);
+        }
+    })
+    .then(err => toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance."));
+};
 
 closeDisplay.addEventListener("click", toggleModal);
 window.addEventListener("click", windowOnClick);

--- a/UI/js/display-dashboard.js
+++ b/UI/js/display-dashboard.js
@@ -50,7 +50,7 @@ fetch('http://127.0.0.1:5000/api/v2/meetups/upcoming/', {
             });
         });
     } else {
-        return data.hasOwnProperty("msg") ? toggleModal(data.msg): data.hasOwnProperty(data.message) ? toggleModal(data.message): toggleModal(data.message.error);
+        return data.hasOwnProperty("msg") ? toggleModal(data.msg): data.hasOwnProperty(data.message) ? toggleModal("Your session has expired. Try to log in again."): toggleModal(data.message.error);
     }
 })
 .catch(err => toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance."));
@@ -67,7 +67,7 @@ const deleteMeetup = (meetupId) => {
         if (data.status == 200) {
             toggleModal("Meetup has been succesfully deleted.");
         } else {
-            toggleModal(data.message.error);
+            return data.hasOwnProperty("msg") ? toggleModal(data.msg): data.hasOwnProperty(data.message) ? toggleModal("Your session has expired. Try to log in again."): toggleModal(data.message.error);
         }
     })
     .then(err => toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance."));

--- a/UI/js/display-meetups.js
+++ b/UI/js/display-meetups.js
@@ -41,7 +41,7 @@ fetch('https://q-questioner-api.herokuapp.com/api/v2/meetups/upcoming/', {
         });
         meetUpTimeline.innerHTML += meetupData;
     } else {
-        return data ? toggleModal(data.msg): toggleModal(data.message.error);
+        return data.hasOwnProperty("msg") ? toggleModal(data.msg): data.hasOwnProperty(data.message) ? toggleModal("Your session has expired. Try to log in again."): toggleModal(data.message.error);
     }
 })
 .catch(err => toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance."));

--- a/UI/js/login.js
+++ b/UI/js/login.js
@@ -40,11 +40,11 @@ const logInUser = (e) => {
                 location.href = "explore.html";
             }
         } else {
-            toggleModal(data.message.error);
+            return data.hasOwnProperty("msg") ? toggleModal(data.msg): data.hasOwnProperty(data.message) ? toggleModal("Your session has expired. Try to log in again."): toggleModal(data.message.error);
         }
     })
-    .catch(_err => {
-        toggleModal(_err.message + ". Email khwilowatai@gmail.com for further assistance.");
+    .catch(err => {
+        toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance.");
     });
 };
 

--- a/UI/js/main.js
+++ b/UI/js/main.js
@@ -40,11 +40,11 @@ const addUser = (e) => {
         if (data.status == 201) {
             toggleModal(data.data[0].message);
         } else {
-            toggleModal(data.message.error);
+            return data.hasOwnProperty("msg") ? toggleModal(data.msg): data.hasOwnProperty(data.message) ? toggleModal("Your session has expired. Try to log in again."): toggleModal(data.message.error);
         }
     })
-    .catch(_err => {
-        toggleModal(_err.message + ". Email khwilowatai@gmail.com for further assistance.");
+    .catch(err => {
+        toggleModal(err.message + ". Email khwilowatai@gmail.com for further assistance.");
     });
 };
 


### PR DESCRIPTION
#### What does this PR do?

Allow an admin user to delete a meetup.

#### Description of Task to be completed?

- [x] Consume the REST API endpoint 
`DELETE https://q-questioner-api.herokuapp.com/api/v2/meetups/<meetup_id>` when deleting a particular meetup.

#### How should this be manually tested?

1.  Clone the repository 
2. Open the file **signin.html** on your web browser and log in to the Questioner web application as an administrator with the following credentials:
    - _username_: **watai**
    - _password_: **questioner_1234**
3. Try to delete a meetup

#### What are the relevant pivotal tracker stories?

[#164132189](https://www.pivotaltracker.com/story/show/164132189)

#### Screenshots

Delete a meetup:

![delete-meetup-ui](https://user-images.githubusercontent.com/5740429/53167274-8a456800-35e8-11e9-8a85-615d78e2575e.gif)
